### PR TITLE
fix: don't shadow parent model attributes

### DIFF
--- a/src/bisque/element/tag_core/main.py
+++ b/src/bisque/element/tag_core/main.py
@@ -1,27 +1,12 @@
 from __future__ import annotations
 
-import warnings
 from typing import ClassVar
 
 from ...typing.tabulation import BaseTypeTable
 from .page_element import BasePageElement
 from .results import BaseResultSet
 from .soup_strainer import BaseSoupStrainer
-from .string_types import (
-    BaseCData,
-    BaseComment,
-    BaseDeclaration,
-    BaseDoctype,
-    BaseNavigableString,
-    BasePreformattedString,
-    BaseProcessingInstruction,
-    BaseRubyParenthesisString,
-    BaseRubyTextString,
-    BaseScript,
-    BaseStylesheet,
-    BaseTemplateString,
-    BaseXMLProcessingInstruction,
-)
+from .string_types import BaseDoctype, BaseNavigableString, BasePreformattedString
 from .tag import BaseTag
 
 __all__ = [
@@ -50,9 +35,6 @@ __all__ = [
     "SoupStrainer",
     "ResultSet",
 ]
-
-# https://github.com/pydantic/pydantic/issues/7009
-warnings.filterwarnings("ignore", message="Field name .* shadows an attribute.*")
 
 
 class TYPE_TABLE(BaseTypeTable):
@@ -114,39 +96,49 @@ class PreformattedString(BasePreformattedString, NavigableString, TabulatedType)
     """
 
 
-class CData(BaseCData, PreformattedString, TabulatedType):
+class CData(PreformattedString, TabulatedType):
     """A CDATA block."""
 
+    PREFIX: str = "<![CDATA["
+    SUFFIX: str = "]]>"
 
-class ProcessingInstruction(
-    BaseProcessingInstruction,
-    PreformattedString,
-    TabulatedType,
-):
+
+class ProcessingInstruction(PreformattedString, TabulatedType):
     """A SGML processing instruction."""
 
+    PREFIX: str = "<?"
+    SUFFIX: str = ">"
 
-class XMLProcessingInstruction(
-    BaseXMLProcessingInstruction,
-    ProcessingInstruction,
-    TabulatedType,
-):
+
+class XMLProcessingInstruction(ProcessingInstruction, TabulatedType):
     """An XML processing instruction."""
 
+    PREFIX: str = "<?"
+    SUFFIX: str = "?>"
 
-class Comment(BaseComment, PreformattedString, TabulatedType):
+
+class Comment(PreformattedString, TabulatedType):
     """An HTML or XML comment."""
 
+    PREFIX: str = "<!--"
+    SUFFIX: str = "-->"
 
-class Declaration(BaseDeclaration, PreformattedString, TabulatedType):
+
+class Declaration(PreformattedString, TabulatedType):
     """An XML declaration."""
+
+    PREFIX: str = "<?"
+    SUFFIX: str = "?>"
 
 
 class Doctype(BaseDoctype, PreformattedString, TabulatedType):
     """A document type declaration."""
 
+    PREFIX: str = "<!DOCTYPE "
+    SUFFIX: str = ">\n"
 
-class Stylesheet(BaseStylesheet, NavigableString, TabulatedType):
+
+class Stylesheet(NavigableString, TabulatedType):
     """A NavigableString representing an stylesheet (probably
     CSS).
 
@@ -154,7 +146,7 @@ class Stylesheet(BaseStylesheet, NavigableString, TabulatedType):
     """
 
 
-class Script(BaseScript, NavigableString, TabulatedType):
+class Script(NavigableString, TabulatedType):
     """A NavigableString representing an executable script (probably
     Javascript).
 
@@ -162,7 +154,7 @@ class Script(BaseScript, NavigableString, TabulatedType):
     """
 
 
-class TemplateString(BaseTemplateString, NavigableString, TabulatedType):
+class TemplateString(NavigableString, TabulatedType):
     """A NavigableString representing a string found inside an HTML
     template embedded in a larger document.
 
@@ -170,7 +162,7 @@ class TemplateString(BaseTemplateString, NavigableString, TabulatedType):
     """
 
 
-class RubyTextString(BaseRubyTextString, NavigableString, TabulatedType):
+class RubyTextString(NavigableString, TabulatedType):
     """A NavigableString representing the contents of the <rt> HTML
     element.
 
@@ -181,7 +173,7 @@ class RubyTextString(BaseRubyTextString, NavigableString, TabulatedType):
     """
 
 
-class RubyParenthesisString(BaseRubyParenthesisString, NavigableString, TabulatedType):
+class RubyParenthesisString(NavigableString, TabulatedType):
     """A NavigableString representing the contents of the <rp> HTML
     element.
 

--- a/src/bisque/element/tag_core/page_element.py
+++ b/src/bisque/element/tag_core/page_element.py
@@ -20,6 +20,7 @@ class BasePageElement:
     NavigableString, Tag, etc. are all subclasses of PageElement.
     """
 
+    default: ClassVar[type] = DEFAULT_TYPES_SENTINEL
     TYPE_TABLE: ClassVar[type]
 
     # In general, we can't tell just by looking at an element whether
@@ -136,8 +137,6 @@ class BasePageElement:
             # used on HTML markup.
             return getattr(self, "is_xml", False)
         return self.parent._is_xml
-
-    default = DEFAULT_TYPES_SENTINEL
 
     def _all_strings(self, strip=False, types=DEFAULT_TYPES_SENTINEL):
         """Yield all strings of certain classes, possibly stripping them.

--- a/src/bisque/element/tag_core/string_types/__init__.py
+++ b/src/bisque/element/tag_core/string_types/__init__.py
@@ -1,31 +1,3 @@
-from .main import (
-    BaseCData,
-    BaseComment,
-    BaseDeclaration,
-    BaseDoctype,
-    BaseNavigableString,
-    BasePreformattedString,
-    BaseProcessingInstruction,
-    BaseRubyParenthesisString,
-    BaseRubyTextString,
-    BaseScript,
-    BaseStylesheet,
-    BaseTemplateString,
-    BaseXMLProcessingInstruction,
-)
+from .main import BaseDoctype, BaseNavigableString, BasePreformattedString
 
-__all__ = [
-    "BaseNavigableString",
-    "BasePreformattedString",
-    "BaseCData",
-    "BaseProcessingInstruction",
-    "BaseXMLProcessingInstruction",
-    "BaseComment",
-    "BaseDeclaration",
-    "BaseDoctype",
-    "BaseStylesheet",
-    "BaseScript",
-    "BaseTemplateString",
-    "BaseRubyTextString",
-    "BaseRubyParenthesisString",
-]
+__all__ = ["BaseDoctype", "BaseNavigableString", "BasePreformattedString"]

--- a/src/bisque/element/tag_core/string_types/main.py
+++ b/src/bisque/element/tag_core/string_types/main.py
@@ -11,17 +11,7 @@ __all__ = [
     # Section 2: string types
     "BaseNavigableString",
     "BasePreformattedString",
-    "BaseCData",
-    "BaseProcessingInstruction",
-    "BaseXMLProcessingInstruction",
-    "BaseComment",
-    "BaseDeclaration",
     "BaseDoctype",
-    "BaseStylesheet",
-    "BaseScript",
-    "BaseTemplateString",
-    "BaseRubyTextString",
-    "BaseRubyParenthesisString",
 ]
 
 # Section 2: Text strings (13 classes)
@@ -184,46 +174,8 @@ class BasePreformattedString:
         return self.PREFIX + str(self) + self.SUFFIX
 
 
-class BaseCData:
-    """A CDATA block."""
-
-    PREFIX: str = "<![CDATA["
-    SUFFIX: str = "]]>"
-
-
-class BaseProcessingInstruction:
-    """A SGML processing instruction."""
-
-    PREFIX: str = "<?"
-    SUFFIX: str = ">"
-
-
-class BaseXMLProcessingInstruction:
-    """An XML processing instruction."""
-
-    PREFIX: str = "<?"
-    SUFFIX: str = "?>"
-
-
-class BaseComment:
-    """An HTML or XML comment."""
-
-    PREFIX: str = "<!--"
-    SUFFIX: str = "-->"
-
-
-class BaseDeclaration:
-    """An XML declaration."""
-
-    PREFIX: str = "<?"
-    SUFFIX: str = "?>"
-
-
 class BaseDoctype:
     """A document type declaration."""
-
-    PREFIX: str = "<!DOCTYPE "
-    SUFFIX: str = ">\n"
 
     @classmethod
     def for_name_and_ids(cls, name, pub_id, system_id):
@@ -247,46 +199,3 @@ class BaseDoctype:
             value += ' SYSTEM "%s"' % system_id
 
         return cls.TYPE_TABLE.Doctype(value)
-
-
-class BaseStylesheet:
-    """A NavigableString representing an stylesheet (probably
-    CSS).
-
-    Used to distinguish embedded stylesheets from textual content.
-    """
-
-
-class BaseScript:
-    """A NavigableString representing an executable script (probably
-    Javascript).
-
-    Used to distinguish executable code from textual content.
-    """
-
-
-class BaseTemplateString:
-    """A NavigableString representing a string found inside an HTML
-    template embedded in a larger document.
-
-    Used to distinguish such strings from the main body of the document.
-    """
-
-
-class BaseRubyTextString:
-    """A NavigableString representing the contents of the <rt> HTML
-    element.
-
-    https://dev.w3.org/html5/spec-LC/text-level-semantics.html#the-rt-element
-
-    Can be used to distinguish such strings from the strings they're
-    annotating.
-    """
-
-
-class BaseRubyParenthesisString:
-    """A NavigableString representing the contents of the <rp> HTML
-    element.
-
-    https://dev.w3.org/html5/spec-LC/text-level-semantics.html#the-rp-element
-    """


### PR DESCRIPTION
This PR removes the need to silence Pydantic warnings about not shadowing parent attributes

- https://github.com/pydantic/pydantic/issues/7009

The test suite now runs without any warnings